### PR TITLE
Added missing namespace to 'provides'

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,7 +3,10 @@
     "version" : "*",
     "description" : "Encode and decode HTML entities",
     "author" : "Alexander Moquin",
-    "provides" : { "HTML::Entity" : "lib/HTML/Entity.pm6" },
+    "provides" : {
+        "HTML::Entity" : "lib/HTML/Entity.pm6",
+        "HTML::Entities" : "lib/HTML/Entities.pm6"
+    },
     "depends" : [ ],
     "source-url" : "git://github.com/Mouq/HTML-Entity.git"
 }


### PR DESCRIPTION
This adds the missing `HTML::Entities`. Without it, panda doesn't install it, and we get errors when trying to use `HTML::Entity`:

```
Could not find HTML::Entities in any of: /home/zoffix/Desktop/CPANPRC/perl6-Pastebin-Shadowcat/lib, /home/zoffix/.perl6/2015.03-151-g049020f/lib, /home/zoffix/.perl6/2015.03-151-g049020f, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/lib, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/vendor/lib, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site/lib, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/vendor, /home/zoffix/.rakudobrew/moar-nom/install/share/perl6/site
  in any load_module at src/gen/m-ModuleLoader.nqp:199
  in method load_module at src/gen/m-CORE.setting:26413
  in sub lazy-load-entities at lib/HTML/Entity.pm6:4
  in sub decode at lib/HTML/Entity.pm6:17
  in sub get_paste at /home/zoffix/Desktop/CPANPRC/perl6-Pastebin-Shadowcat/lib/Pastebin/Shadowcat.pm6:24
  in block <unit> at examples/paste.pl6:6
```
