### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
     "name" : "HTML::Entity",
+    "license" : "Artistic-2.0",
     "version" : "*",
     "description" : "Encode and decode HTML entities",
     "author" : "Alexander Moquin",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license